### PR TITLE
Parse escape sequences in strings

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -57,8 +57,14 @@ testExpressions = describe "Parse literals:" $ do
   it "strings" $ do
     shouldBe (testExpression "\"test\"")
       "Right (LS \"test\")"
-    shouldBe (testExpression "\'test\'")
+    shouldBe (testExpression "'test'")
       "Right (LS \"test\")"
+    shouldBe (testExpression "'\\''")
+      "Right (LS \"'\")"
+    shouldBe (testExpression "'\\n'")
+      "Right (LS \"\\n\")"
+    shouldBe (testExpression "'\n'")
+      "Left \"dummy.js\" (line 1, column 2):\nunexpected \"\\n\"\nexpecting \"\\\\\" or \"'\""
 
   it "template string" $ do
     shouldBe (testExpression "`test`")


### PR DESCRIPTION
This parses and tests escape sequences like `'\n'` in JS strings. It's definetly not fulfilling the standard, but that's not a rabbit hole I'm willing to go down and it is enough for my use case atm.

Thanks to [this beautiful SO question](https://codereview.stackexchange.com/questions/2406/parsing-strings-with-escaped-characters-using-parsec), that helped me write it:
